### PR TITLE
A64: Add EOR3 and BCAX support

### DIFF
--- a/qemu/target-arm/cpu.h
+++ b/qemu/target-arm/cpu.h
@@ -749,6 +749,7 @@ enum arm_features {
     ARM_FEATURE_V8_SHA1, /* implements SHA1 part of v8 Crypto Extensions */
     ARM_FEATURE_V8_SHA256, /* implements SHA256 part of v8 Crypto Extensions */
     ARM_FEATURE_V8_PMULL, /* implements PMULL part of v8 Crypto Extensions */
+    ARM_FEATURE_V8_SHA3, /* implements SHA3 part of v8 Crypto Extensions */
 };
 
 static inline int arm_feature(CPUARMState *env, int feature)


### PR DESCRIPTION
Backported to unicorn from: https://lists.nongnu.org/archive/html/qemu-devel/2018-01/msg05003.html